### PR TITLE
mark conntrack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,7 +849,7 @@ impl Queue {
             if conntrack.mark_dirty {
                 let mut nested_nlmsg = nlmsg.nested(NFQA_CT as u16);
                 nested_nlmsg.put_be32(CTA_MARK as u16, conntrack.mark);
-                nlmsg.finish_nested(&mut nested_nlmsg);
+                nlmsg.finish_nested(nested_nlmsg);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,9 +847,9 @@ impl Queue {
 
         if let Some(ref conntrack) = msg.ct {
             if conntrack.mark_dirty {
-                let mut nested_nlmsg = NlmsgMut::nested(NFQA_CT as u16);
+                let mut nested_nlmsg = nlmsg.nested(NFQA_CT as u16);
                 nested_nlmsg.put_be32(CTA_MARK as u16, conntrack.mark);
-                nested_nlmsg.finish_nested(&mut nlmsg);
+                nlmsg.finish_nested(&mut nested_nlmsg);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,12 +847,9 @@ impl Queue {
 
         if let Some(ref conntrack) = msg.ct {
             if conntrack.mark_dirty {
-                let mut nested_nlmsg = NlmsgMut::with_capacity(1024);
+                let mut nested_nlmsg = NlmsgMut::nested(NFQA_CT as u16);
                 nested_nlmsg.put_be32(CTA_MARK as u16, conntrack.mark);
-                let conntrack_buffer = nested_nlmsg.finish();
-
-                // Create a nested conntrack nlmsg within the main nlmsg
-                nlmsg.put_bytes(NFQA_CT as u16, &conntrack_buffer);
+                nested_nlmsg.finish_nested(&mut nlmsg);
             }
         }
 

--- a/src/nlmsg.rs
+++ b/src/nlmsg.rs
@@ -19,8 +19,35 @@ pub const IP_CT_RELATED_REPLY: u32 = 4;
 pub const IP_CT_NUMBER: u32 = 5;
 pub const IP_CT_NEW_REPLY: u32 = 5;
 
+pub const CTA_UNSPEC: u32 = 0;
+pub const CTA_TUPLE_ORIG: u32 = 1;
+pub const CTA_TUPLE_REPLY: u32 = 2;
+pub const CTA_STATUS: u32 = 3;
+pub const CTA_PROTOINFO: u32 = 4;
+pub const CTA_HELP: u32 = 5;
+pub const CTA_NAT_SRC: u32 = 6;
+pub const CTA_TIMEOUT: u32 = 7;
 pub const CTA_MARK: u32 = 8;
+pub const CTA_COUNTERS_ORIG: u32 = 9;
+pub const CTA_COUNTERS_REPLY: u32 = 10;
+pub const CTA_USE: u32 = 11;
 pub const CTA_ID: u32 = 12;
+pub const CTA_NAT_DST: u32 = 13;
+pub const CTA_TUPLE_MASTER: u32 = 14;
+pub const CTA_SEQ_ADJ_ORIG: u32 = 15;
+pub const CTA_NAT_SEQ_ADJ_ORIG: u32 = CTA_SEQ_ADJ_ORIG;
+pub const CTA_SEQ_ADJ_REPLY: u32 = 17;
+pub const CTA_NAT_SEQ_ADJ_REPLY: u32 = CTA_SEQ_ADJ_REPLY;
+pub const CTA_SECMARK: u32 = 19; // obsolete
+pub const CTA_ZONE: u32 = 20;
+pub const CTA_SECCTX: u32 = 21;
+pub const CTA_TIMESTAMP: u32 = 22;
+pub const CTA_MARK_MASK: u32 = 23;
+pub const CTA_LABELS: u32 = 24;
+pub const CTA_LABELS_MASK: u32 = 25;
+pub const CTA_SYNPROXY: u32 = 26;
+pub const CTA_FILTER: u32 = 27;
+pub const CTA_STATUS_MASK: u32 = 28;
 
 #[repr(C)]
 #[derive(Clone, Copy, Zeroable, Pod)]
@@ -122,15 +149,13 @@ impl NlmsgMut {
     }
 
     pub fn nested(ty: u16) -> Self {
-        const NLA_F_NESTED: u16 = 1 << 15;
-
-        // 12 => sizeof(ty) + sizeof(nested_attr_ty) + sizeof(nest_attr_data_u32)
+        // 12 => sizeof(ty) + sizeof(nested_attr_ty) + sizeof(nested_attr_data_u32)
         let mut buffer = Self(BytesMut::with_capacity(12));
 
         // len of NlAttr will be updated by finish_nested
         buffer.0.put_slice(bytemuck::bytes_of(&NlAttr {
             len: 0,
-            ty: ty | NLA_F_NESTED,
+            ty: ty | libc::NLA_F_NESTED as u16,
         }));
         buffer
     }

--- a/src/nlmsg.rs
+++ b/src/nlmsg.rs
@@ -19,6 +19,7 @@ pub const IP_CT_RELATED_REPLY: u32 = 4;
 pub const IP_CT_NUMBER: u32 = 5;
 pub const IP_CT_NEW_REPLY: u32 = 5;
 
+pub const CTA_MARK: u32 = 8;
 pub const CTA_ID: u32 = 12;
 
 #[repr(C)]

--- a/src/nlmsg.rs
+++ b/src/nlmsg.rs
@@ -160,7 +160,7 @@ impl NlmsgMut {
         Self(nested_buffer)
     }
 
-    pub fn finish_nested(&mut self, nested: &mut NlmsgMut) {
+    pub fn finish_nested(&mut self, mut nested: NlmsgMut) {
         let len = nested.0.len();
         let header: &mut NlAttr =
             bytemuck::from_bytes_mut(&mut nested.0[..core::mem::size_of::<NlAttr>()]);


### PR DESCRIPTION
Hello there,

I'm trying to implement conntrack marks, but it has been unsuccessful so far. I thought I would still open a PR so that maybe you can give me some pointers or spot something obviously wrong in my code.

My goal is to achieve the following:
- Send "about-to-be-dropped" packets to my userspace program
- For now my userspace program only processes TCP packets, if I see a SYN, I reply with a SYN-ACK and mark the conntrack with the id `0x1337`
- Further incoming packets related to this TCP session should be marked by netfilter
- Send the packets marked with my ID to the netfilter queue right away

Most firewall rules, mine included, default to accept established/related packets. Therefore once I complete the TCP handshake I no longer receive the packets that follow, which is an issue for what I need to do.

So far my nftables rules look like this (some details were omitted) :

```
table inet filter {
  chain input {
    type filter hook input priority 0; policy drop;
    ct state invalid drop comment "early drop of invalid packets"

    # Send to the netfilter_queue packets marked with 0x1337 for userspace processing
    ct mark 0x1337 counter queue num 0

    # Accept already established/related connections
    ct state {established, related} accept comment "accept all connections related to connections made by us"

    # Log any failed inbound traffic attempt
    log flags all prefix "FIREWALL REJECTED INPUT: " counter

    # Send packet about to be dropped to the netfilter_queue for userspace processing
    counter queue num 0
  }
}
```

But when I look at the output of `nft list table ruleset`, I can see that the following rule is never matched:

```
ct mark 0x00001337 counter packets 0 bytes 0 queue to 0
```

Do you have any idea of what I could have done wrong ?

The `libnetfilter_conntrack` sets the conntrack mark in the following function:

[line 392 of libnetfilter_conntrack/tree/src/conntrack/build_mnl.c](https://git.netfilter.org/libnetfilter_conntrack/tree/src/conntrack/build_mnl.c?id=7a8e1e223cdf13720268527c99702ff3d22b40dc#n392) 

`CTA_MARK` is defined [here in the kernel source code](https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/netfilter/nfnetlink_conntrack.h#L39)