### PR TITLE
Don't include the length of the padding in nlattr.len

### DIFF
--- a/src/nlmsg.rs
+++ b/src/nlmsg.rs
@@ -133,15 +133,16 @@ impl NlmsgMut {
 
     /// Put a slice of arbitary data.
     pub fn put_bytes(&mut self, ty: u16, data: &[u8]) {
-        let data_len = data.len().next_multiple_of(4);
+        let data_len = data.len();
         let total_len: u16 = (data_len + core::mem::size_of::<NlAttr>())
             .try_into()
             .unwrap();
 
         self.0.put_slice(NlAttr { len: total_len, ty }.as_bytes());
         self.0.put_slice(data);
-        // Insert padding
-        self.0.put_bytes(0, data_len - data.len());
+        // The padding is not counted by NlAttr
+        let padding_len = data_len.next_multiple_of(4) - data_len;
+        self.0.put_bytes(0, padding_len);
     }
 
     /// Put an arbitrary data.


### PR DESCRIPTION
Fixes https://github.com/nbdd0121/nfq-rs/issues/19

As already stated in the issue, `nlattr.nla_len` doesn't need to include the padding in its length, because the kernel already moves to the next `nlattr` in the netlink message by compensating for alignment.